### PR TITLE
Improve test coverage

### DIFF
--- a/test/lunchmoney/errors_test.rb
+++ b/test/lunchmoney/errors_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 module LunchMoney
   class ErrorsTest < ActiveSupport::TestCase
     setup do
-      @error = LunchMoney::Errors.new
+      @error = T.let(LunchMoney::Errors.new, LunchMoney::Errors)
     end
 
     test "initializes error with message" do

--- a/test/lunchmoney/errors_test.rb
+++ b/test/lunchmoney/errors_test.rb
@@ -1,0 +1,45 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "test_helper"
+
+module LunchMoney
+  class ErrorsTest < ActiveSupport::TestCase
+    setup do
+      @error = LunchMoney::Errors.new
+    end
+
+    test "initializes error with message" do
+      error = LunchMoney::Errors.new(message: "Some error message")
+
+      assert_equal(["Some error message"], error.messages)
+    end
+
+    test "initializes error without message" do
+      error = LunchMoney::Errors.new
+
+      assert_empty(error.messages)
+    end
+
+    test "can add messages to error" do
+      @error.messages << "Error 1"
+      @error.messages << "Error 2"
+
+      assert_equal(["Error 1", "Error 2"], @error.messages)
+    end
+
+    test "can get first message" do
+      @error.messages << "Error 1"
+      @error.messages << "Error 2"
+
+      assert_equal("Error 1", @error.first)
+    end
+
+    test "can check if error messages are empty" do
+      assert_empty(@error)
+      @error.messages << "Error"
+
+      refute_empty(@error)
+    end
+  end
+end

--- a/test/lunchmoney/objects/object_test.rb
+++ b/test/lunchmoney/objects/object_test.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "test_helper"
+
+module LunchMoney
+  module Objects
+    class ObjectTest < ActiveSupport::TestCase
+      test "serialize returns a hash of instance variables" do
+        object = create_test_object
+        expected = {
+          "name" => object.instance_variable_get(:@name),
+          "type" => object.instance_variable_get(:@type),
+          "subtype" => object.instance_variable_get(:@subtype),
+          "balance" => object.instance_variable_get(:@balance),
+          "balance_as_of" => object.instance_variable_get(:@balance_as_of),
+          "created_at" => object.instance_variable_get(:@created_at),
+        }
+
+        assert_equal(expected, object.serialize)
+      end
+
+      test "serialize returns a hash of instance variables with symbolized keys" do
+        object = create_test_object
+        expected = {
+          name: object.instance_variable_get(:@name),
+          type: object.instance_variable_get(:@type),
+          subtype: object.instance_variable_get(:@subtype),
+          balance: object.instance_variable_get(:@balance),
+          balance_as_of: object.instance_variable_get(:@balance_as_of),
+          created_at: object.instance_variable_get(:@created_at),
+        }
+
+        assert_equal(expected, object.serialize(symbolize_keys: true))
+      end
+
+      private
+
+      sig { returns(LunchMoney::Objects::Object) }
+      def create_test_object
+        object = LunchMoney::Objects::Object.new
+        object.instance_variable_set(:@name, "Test Name")
+        object.instance_variable_set(:@type, "Test Type")
+        object.instance_variable_set(:@subtype, "Test Subtype")
+        object.instance_variable_set(:@balance, 1000)
+        object.instance_variable_set(:@balance_as_of, "2023-01-01T01:01:01.000Z")
+        object.instance_variable_set(:@created_at, "2023-01-01T01:01:01.000Z")
+
+        object
+      end
+    end
+  end
+end

--- a/test/lunchmoney/validators_test.rb
+++ b/test/lunchmoney/validators_test.rb
@@ -72,4 +72,12 @@ class ValidatorsTest < ActiveSupport::TestCase
 
     assert_match(/is not a valid ISO 8601 string/, error.message)
   end
+
+  test "validate_iso8601 raises an ArgumentError when the message is not invalid xmlschema format" do
+    Time.expects(:iso8601).raises(ArgumentError, "unexpected error return")
+
+    assert_raises(ArgumentError) do
+      validate_iso8601!("2023-01-01")
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/mmenanno/lunchmoney/issues/216 within a reasonable manner for now. Line coverage stayed the same but I got branch coverage up to 95.04%. The remaining cases would benefit from tweaking the dummy cases so that VCR cassettes in existing tests have more object variance examples.